### PR TITLE
feat: add notes to todo items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A minimal ToDo app built with Next.js (App Router) and client-side persistence v
 
 ## Features
 - Add, toggle, delete todos
+- Add notes to todos
 - Filter: All / Active / Completed
 - Clear completed
 - Persist in `localStorage`

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,7 +88,17 @@ body {
 .item:last-child { border-bottom: none; }
 .checkbox { display: flex; align-items: center; gap: 10px; flex: 1; }
 .checkbox input { width: 18px; height: 18px; }
+.texts { display: flex; flex-direction: column; }
 .done { text-decoration: line-through; color: var(--muted); }
+.note { color: var(--muted); font-size: 0.9em; }
+.noteBtn {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
 .delBtn {
   background: transparent;
   border: none;

--- a/app/page.js
+++ b/app/page.js
@@ -43,7 +43,7 @@ export default function Page() {
     e.preventDefault();
     const trimmed = text.trim();
     if (!trimmed) return;
-    setTodos(prev => [{ id: uid(), text: trimmed, completed: false }, ...prev]);
+    setTodos(prev => [{ id: uid(), text: trimmed, note: '', completed: false }, ...prev]);
     setText('');
   }
 
@@ -57,6 +57,14 @@ export default function Page() {
 
   function clearCompleted() {
     setTodos(prev => prev.filter(t => !t.completed));
+  }
+
+  function editNote(id) {
+    const current = todos.find(t => t.id === id)?.note || '';
+    const note = prompt('備考を入力', current);
+    if (note !== null) {
+      setTodos(prev => prev.map(t => (t.id === id ? { ...t, note } : t)));
+    }
   }
 
   return (
@@ -115,8 +123,14 @@ export default function Page() {
                 checked={todo.completed}
                 onChange={() => toggleTodo(todo.id)}
               />
-              <span className={todo.completed ? 'done' : ''}>{todo.text}</span>
+              <span className="texts">
+                <span className={todo.completed ? 'done' : ''}>{todo.text}</span>
+                {todo.note && <span className="note">{todo.note}</span>}
+              </span>
             </label>
+            <button className="noteBtn" onClick={() => editNote(todo.id)} aria-label="備考">
+              備考
+            </button>
             <button className="delBtn" onClick={() => removeTodo(todo.id)} aria-label="削除">
               ×
             </button>


### PR DESCRIPTION
## Summary
- allow todos to hold optional notes with an edit button
- style note display and buttons
- document note capability in README

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b40fff8a788330916f49f379bcd34a